### PR TITLE
Input as env in composite action

### DIFF
--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: "Input for environment variables."
         env:
-          EXTERNAL_ENV: value
+          GHA_TEST_EXTERNAL_ENV: value
         uses: ./actions/input-as-env
         with:
           envs: |
             {
-              "SPECIAL_ENV": "special",
-              "OTHER_SPECIAL": "other"
+              "GHA_TEST_SPECIAL_ENV": "special",
+              "GHA_TEST_OTHER_SPECIAL": "other"
             }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -29,6 +29,8 @@ jobs:
       - name: "Input for environment variables."
         env:
           GHA_TEST_EXTERNAL_ENV: value
+          GHA_TEST_EXTERNAL_BOOL: false,
+          GHA_TEST_EXTERNAL_NUM: 3.1415,
         uses: ./actions/input-as-env
         with:
           envs: |

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -29,8 +29,9 @@ jobs:
       - name: "Input for environment variables."
         env:
           GHA_TEST_EXTERNAL_ENV: value
-          GHA_TEST_EXTERNAL_BOOL: false,
-          GHA_TEST_EXTERNAL_NUM: 3.1415,
+          GHA_TEST_EXTERNAL_BOOL: false
+          GHA_TEST_EXTERNAL_NUM: 3.1415
+          GHA_TEST_EXTERNAL_EXPR: ${{ 1 + 2 }}
         uses: ./actions/input-as-env
         with:
           envs: |
@@ -38,4 +39,5 @@ jobs:
               "GHA_TEST_SPECIAL_ENV": "special",
               "GHA_TEST_SPECIAL_BOOL": false,
               "GHA_TEST_SPECIAL_NUM": 3.1415,
+              "GHA_TEST_SPECIAL_EXPR": ${{ 1 + 2 }}
             }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -31,7 +31,7 @@ jobs:
           GHA_TEST_EXTERNAL_ENV: value
           GHA_TEST_EXTERNAL_BOOL: false
           GHA_TEST_EXTERNAL_NUM: 3.1415
-          GHA_TEST_EXTERNAL_EXPR: ${{ format('foo {} bar', github.sha) }}
+          GHA_TEST_EXTERNAL_EXPR: ${{ format('foo {0} bar', github.sha) }}
         uses: ./actions/input-as-env
         with:
           envs: |
@@ -39,5 +39,5 @@ jobs:
               "GHA_TEST_SPECIAL_ENV": "special",
               "GHA_TEST_SPECIAL_BOOL": false,
               "GHA_TEST_SPECIAL_NUM": 3.1415,
-              "GHA_TEST_SPECIAL_EXPR": ${{ toJSON(format('foo {} bar', github.sha)) }}
+              "GHA_TEST_SPECIAL_EXPR": ${{ toJSON(format('foo {0} bar', github.sha)) }}
             }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -2,6 +2,7 @@ name: "Inputs"
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   job:
@@ -24,3 +25,14 @@ jobs:
         env:
           VAR_FOR_INPUT: value
           HIDDEN_ECHO: hidden-value
+
+      - name: "Input for environment variables."
+        env:
+          EXTERNAL_ENV: value
+        uses: ./actions/input-as-env
+        with:
+          envs: |
+            {
+              "SPECIAL_ENV": "special",
+              "OTHER_SPECIAL": "other"
+            }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -31,7 +31,7 @@ jobs:
           GHA_TEST_EXTERNAL_ENV: value
           GHA_TEST_EXTERNAL_BOOL: false
           GHA_TEST_EXTERNAL_NUM: 3.1415
-          GHA_TEST_EXTERNAL_EXPR: ${{ 1 + 2 }}
+          GHA_TEST_EXTERNAL_EXPR: ${{ format('foo {} bar', github.sha) }}
         uses: ./actions/input-as-env
         with:
           envs: |
@@ -39,5 +39,5 @@ jobs:
               "GHA_TEST_SPECIAL_ENV": "special",
               "GHA_TEST_SPECIAL_BOOL": false,
               "GHA_TEST_SPECIAL_NUM": 3.1415,
-              "GHA_TEST_SPECIAL_EXPR": ${{ 1 + 2 }}
+              "GHA_TEST_SPECIAL_EXPR": ${{ toJSON(format('foo {} bar', github.sha)) }}
             }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: "Input for environment variables."
         env:
-          GHA_TEST_EXTERNAL_ENV: value
+          GHA_TEST_EXTERNAL_STR: value
           GHA_TEST_EXTERNAL_BOOL: false
           GHA_TEST_EXTERNAL_NUM: 3.1415
           GHA_TEST_EXTERNAL_EXPR: ${{ format('foo {0} bar', github.sha) }}
@@ -36,7 +36,7 @@ jobs:
         with:
           envs: |
             {
-              "GHA_TEST_SPECIAL_ENV": "special",
+              "GHA_TEST_SPECIAL_STR": "special",
               "GHA_TEST_SPECIAL_BOOL": false,
               "GHA_TEST_SPECIAL_NUM": 3.1415,
               "GHA_TEST_SPECIAL_EXPR": ${{ toJSON(format('foo {0} bar', github.sha)) }}

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -34,5 +34,6 @@ jobs:
           envs: |
             {
               "GHA_TEST_SPECIAL_ENV": "special",
-              "GHA_TEST_OTHER_SPECIAL": "other"
+              "GHA_TEST_SPECIAL_BOOL": false,
+              "GHA_TEST_SPECIAL_NUM": 3.1415,
             }

--- a/.github/workflows/inputs.yml
+++ b/.github/workflows/inputs.yml
@@ -2,7 +2,6 @@ name: "Inputs"
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   job:

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -12,14 +12,14 @@ runs:
 
     - name: "Output env"
       shell: bash
-      run: env
+      run: env | grep GHA_TEST_
 
     - name: "Output env with inputs"
       shell: bash
-      run: env
+      run: env | grep GHA_TEST_
       env: ${{ fromJSON(inputs.envs) }}
 
     - name: "Output env with inputs (badly?)"
       shell: bash
-      run: env
+      run: env | grep GHA_TEST_
       env: ${{ inputs.envs }}

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -1,0 +1,25 @@
+name: "Input as env"
+description: "Uses input JSON as environment for execution."
+
+inputs:
+  envs:
+    description: 'JSON-encoded object which contains environment variables.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: "Output env"
+      shell: bash
+      run: env
+
+    - name: "Output env with inputs"
+      shell: bash
+      run: env
+      env: ${{ fromJSON(inputs.envs) }}
+
+    - name: "Output env with inputs (badly?)"
+      shell: bash
+      run: env
+      env: ${{ inputs.envs }}

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -14,7 +14,16 @@ runs:
       shell: bash
       run: env | grep GHA_TEST_
 
-    - name: "Output env with inputs"
+    - name: "Output env"
+      env:
+        GHA_TEST_INTERNAL_STR: 'value'
+        GHA_TEST_INTERNAL_BOOL: false
+        GHA_TEST_INTERNAL_NUM: 3.1415
+        GHA_TEST_INTERNAL_EXPR: ${{ 1 + 2 }}
       shell: bash
       run: env | grep GHA_TEST_
+
+    - name: "Output env with inputs"
       env: ${{ fromJSON(inputs.envs) }}
+      shell: bash
+      run: env | grep GHA_TEST_

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: "Output env"
       shell: bash
-      run: env | grep GHA_TEST_
+      run: env | grep GHA_TEST_ | sort
 
     - name: "Output env"
       env:
@@ -21,9 +21,9 @@ runs:
         GHA_TEST_INTERNAL_NUM: 3.1415
         GHA_TEST_INTERNAL_EXPR: ${{ format('foo {0} bar', github.sha) }}
       shell: bash
-      run: env | grep GHA_TEST_
+      run: env | grep GHA_TEST_ | sort
 
     - name: "Output env with inputs"
       env: ${{ fromJSON(inputs.envs) }}
       shell: bash
-      run: env | grep GHA_TEST_
+      run: env | grep GHA_TEST_ | sort

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -19,7 +19,7 @@ runs:
         GHA_TEST_INTERNAL_STR: 'value'
         GHA_TEST_INTERNAL_BOOL: false
         GHA_TEST_INTERNAL_NUM: 3.1415
-        GHA_TEST_INTERNAL_EXPR: ${{ 1 + 2 }}
+        GHA_TEST_INTERNAL_EXPR: ${{ format('foo {} bar', github.sha) }}
       shell: bash
       run: env | grep GHA_TEST_
 

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -18,8 +18,3 @@ runs:
       shell: bash
       run: env | grep GHA_TEST_
       env: ${{ fromJSON(inputs.envs) }}
-
-    - name: "Output env with inputs (badly?)"
-      shell: bash
-      run: env | grep GHA_TEST_
-      env: ${{ inputs.envs }}

--- a/actions/input-as-env/action.yml
+++ b/actions/input-as-env/action.yml
@@ -19,7 +19,7 @@ runs:
         GHA_TEST_INTERNAL_STR: 'value'
         GHA_TEST_INTERNAL_BOOL: false
         GHA_TEST_INTERNAL_NUM: 3.1415
-        GHA_TEST_INTERNAL_EXPR: ${{ format('foo {} bar', github.sha) }}
+        GHA_TEST_INTERNAL_EXPR: ${{ format('foo {0} bar', github.sha) }}
       shell: bash
       run: env | grep GHA_TEST_
 


### PR DESCRIPTION
 * Test for https://github.com/TWiStErRob/net.twisterrob.ghlint/issues/221
 * Test for https://github.com/SchemaStore/schemastore/pull/3821


```
    - name: "Output env with inputs (badly)"
      shell: bash
      run: env | grep GHA_TEST_
      env: ${{ inputs.envs }}
```

![image](https://github.com/TWiStErRob/github-actions-test/assets/2906988/debd7f10-7f70-40b6-9bf2-657d87f0651c)
