### PR TITLE
Test: GitHub Actions boolean input serialization

### DIFF
--- a/.github/workflows/boolean-serialization-caller.yml
+++ b/.github/workflows/boolean-serialization-caller.yml
@@ -1,0 +1,22 @@
+name: "Boolean Serialization (caller)"
+
+on:
+  push:
+    branches: [tw/test-boolean-serialization]
+
+jobs:
+  call-with-default:
+    name: "Call with default (false)"
+    uses: ./.github/workflows/boolean-serialization.yml
+
+  call-with-false:
+    name: "Call with explicit false"
+    uses: ./.github/workflows/boolean-serialization.yml
+    with:
+      dry-run: false
+
+  call-with-true:
+    name: "Call with explicit true"
+    uses: ./.github/workflows/boolean-serialization.yml
+    with:
+      dry-run: true

--- a/.github/workflows/boolean-serialization.yml
+++ b/.github/workflows/boolean-serialization.yml
@@ -51,6 +51,13 @@ jobs:
           echo "::notice::toJSON: '$VALUE'"
           echo "::notice::toJSON length: ${#VALUE}"
 
+      - name: "Short-circuit &&"
+        env:
+          VALUE: ${{ false && 'text' }}
+        run: |
+          echo "::notice::false-and-text: '$VALUE'"
+          echo "::notice::false-and-text length: ${#VALUE}"
+
       - name: "Type checks"
         env:
           IS_NULL: ${{ inputs.dry-run == null }}

--- a/.github/workflows/boolean-serialization.yml
+++ b/.github/workflows/boolean-serialization.yml
@@ -1,0 +1,64 @@
+name: "Boolean Serialization"
+
+on:
+  push:
+    branches: [tw/test-boolean-serialization]
+  workflow_call:
+    inputs:
+      dry-run:
+        description: "A boolean input"
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  test:
+    name: "Test boolean serialization"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Direct interpolation"
+        env:
+          VALUE: ${{ inputs.dry-run }}
+        run: |
+          echo "::notice::direct: '$VALUE'"
+          echo "::notice::direct length: ${#VALUE}"
+
+      - name: "With || 'false'"
+        env:
+          VALUE: ${{ inputs.dry-run || 'false' }}
+        run: |
+          echo "::notice::or-false: '$VALUE'"
+          echo "::notice::or-false length: ${#VALUE}"
+
+      - name: "With ternary"
+        env:
+          VALUE: ${{ inputs.dry-run && 'true' || 'false' }}
+        run: |
+          echo "::notice::ternary: '$VALUE'"
+          echo "::notice::ternary length: ${#VALUE}"
+
+      - name: "format() function"
+        env:
+          VALUE: ${{ format('{0}', inputs.dry-run) }}
+        run: |
+          echo "::notice::format: '$VALUE'"
+          echo "::notice::format length: ${#VALUE}"
+
+      - name: "toJSON()"
+        env:
+          VALUE: ${{ toJSON(inputs.dry-run) }}
+        run: |
+          echo "::notice::toJSON: '$VALUE'"
+          echo "::notice::toJSON length: ${#VALUE}"
+
+      - name: "Type checks"
+        env:
+          IS_NULL: ${{ inputs.dry-run == null }}
+          IS_FALSE: ${{ inputs.dry-run == false }}
+          IS_EMPTY: ${{ inputs.dry-run == '' }}
+          TYPE_OF: ${{ toJSON(inputs.dry-run) }}
+        run: |
+          echo "::notice::== null: '$IS_NULL'"
+          echo "::notice::== false: '$IS_FALSE'"
+          echo "::notice::== '': '$IS_EMPTY'"
+          echo "::notice::toJSON: '$TYPE_OF'"


### PR DESCRIPTION
## Purpose

Prove how GitHub Actions serializes boolean `workflow_call` inputs in different contexts, specifically when `inputs.dry-run` is null (on `push` trigger where `workflow_call` inputs do not exist).

## Results

| Expression | `push` (null) | `workflow_call` default | `workflow_call` explicit `false` | `workflow_call` explicit `true` |
|---|---|---|---|---|
| `${{ inputs.dry-run }}` (direct) | **`""` ⚠️** | `"false"` | `"false"` | `"true"` |
| `${{ inputs.dry-run \|\| 'false' }}` | `"false"` | `"false"` | `"false"` | `"true"` |
| `${{ inputs.dry-run && 'true' \|\| 'false' }}` | `"false"` | `"false"` | `"false"` | `"true"` |
| `${{ format('{0}', inputs.dry-run) }}` | **`""` ⚠️** | `"false"` | `"false"` | `"true"` |
| `${{ toJSON(inputs.dry-run) }}` | `"null"` | `"false"` | `"false"` | `"true"` |
| `${{ false && 'text' }}` | `"false"` | `"false"` | `"false"` | `"true"` |
| `== null` | `true` | `true` 🤔 | `true` 🤔 | `false` |
| `== false` | `true` | `true` 🤔 | `true` 🤔 | `false` |
| `== ''` | `true` | `true` 🤔 | `true` 🤔 | `false` |
| `toJSON()` | `null` | `false` | `false` | `true` |

## Key Findings

1. **`inputs.dry-run` is `null` on push trigger** — NOT `false`. The `workflow_call` input default does not apply.
2. **`null` serializes to `""`** (empty string) in string context.
3. **Boolean `false` serializes to `"false"`** (5-char string) — not empty.
4. **GHA loose equality**: `false == null == "" == true` — all three are interchangeable in comparisons.
5. `format()` does NOT help — also produces `""` for null.
6. `${{ false && 'text' }}` → `"false"` — short-circuit `&&` with falsy LHS returns the string `"false"`, not empty.
7. Both `|| 'false'` and ternary patterns work correctly for all scenarios.

## CI Runs

- Push (null inputs): https://github.com/TWiStErRob/github-actions-test/actions/runs/24738251998
- Caller (3 scenarios): https://github.com/TWiStErRob/github-actions-test/actions/runs/24738252027