### PR TITLE
Test: workflow-level env accessible in step with:

### DIFF
--- a/.github/workflows/env-in-with.yml
+++ b/.github/workflows/env-in-with.yml
@@ -1,0 +1,19 @@
+name: "Env in with:"
+
+on:
+  push:
+    branches: [tw/test-env-in-with]
+
+env:
+  RESOLVED: ${{ inputs.dry-run || false }}
+
+jobs:
+  test:
+    name: "Test env in with:"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Use env in with:"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.notice(`env.RESOLVED: '${process.env.RESOLVED}'`);


### PR DESCRIPTION
## Purpose

Verify that a workflow-level `env:` variable (resolved from `inputs.dry-run || false`) is accessible inside a step's `with:` block via `${{ env.X }}`.

## Result

✅ **Confirmed working.** `env.RESOLVED` resolves to `'false'` when accessed from `process.env.RESOLVED` inside `actions/github-script` `with: script:`.

```
env.RESOLVED: 'false'
```

## CI Run

https://github.com/TWiStErRob/github-actions-test/actions/runs/24738600449

## Context

This validates the approach used in I#16224, where `inputs.dry-run || false` is resolved once at workflow level and referenced by 5 `track-workflow-result` steps.